### PR TITLE
codegen: use cockroachdb/errors package

### DIFF
--- a/cmd/protoc-gen-go-drpc/main.go
+++ b/cmd/protoc-gen-go-drpc/main.go
@@ -442,9 +442,9 @@ func (d *drpc) generateServerSignature(method *protogen.Method) string {
 func (d *drpc) generateUnimplementedServerMethod(method *protogen.Method) {
 	d.P("func (s *", d.ServerUnimpl(method.Parent), ") ", d.generateServerSignature(method), " {")
 	if !method.Desc.IsStreamingServer() && !method.Desc.IsStreamingClient() {
-		d.P("return nil, ", d.Ident("storj.io/drpc/drpcerr", "WithCode"), "(", d.Ident("errors", "New"), "(\"Unimplemented\"), ", d.Ident("storj.io/drpc/drpcerr", "Unimplemented"), ")")
+		d.P("return nil, ", d.Ident("storj.io/drpc/drpcerr", "WithCode"), "(", d.Ident("github.com/cockroachdb/errors", "New"), "(\"Unimplemented\"), ", d.Ident("storj.io/drpc/drpcerr", "Unimplemented"), ")")
 	} else {
-		d.P("return ", d.Ident("storj.io/drpc/drpcerr", "WithCode"), "(", d.Ident("errors", "New"), "(\"Unimplemented\"), ", d.Ident("storj.io/drpc/drpcerr", "Unimplemented"), ")")
+		d.P("return ", d.Ident("storj.io/drpc/drpcerr", "WithCode"), "(", d.Ident("github.com/cockroachdb/errors", "New"), "(\"Unimplemented\"), ", d.Ident("storj.io/drpc/drpcerr", "Unimplemented"), ")")
 	}
 	d.P("}")
 	d.P()


### PR DESCRIPTION
The `cockroachdb` linters don't allow using the standard `errors` package, even in generated `*_drpc.pb.go` files.
This change replaces its usage in `UnimplementedServer` with `cockroachdb/errors` to comply with linting requirements.

Informs: https://github.com/cockroachdb/cockroach/issues/145954