### PR TITLE
drpcconn,drpcinterceptors: create interface for client interceptors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 vendor
 result
+.idea/*

--- a/drpcconn/conn_test.go
+++ b/drpcconn/conn_test.go
@@ -5,7 +5,9 @@ package drpcconn
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
 	"net"
+	"storj.io/drpc/drpcinterceptors"
 	"testing"
 	"time"
 
@@ -82,5 +84,177 @@ func TestConn_InvokeFlushesSendClose(t *testing.T) {
 	case <-conn.Closed():
 	case <-time.After(1 * time.Second):
 		t.Fatal("took too long for conn to be closed")
+	}
+}
+
+func runStreamServerSide(ps net.Conn, t *testing.T, sendMessage bool, done chan struct{}) {
+	rd := drpcwire.NewReader(ps)
+	wr := drpcwire.NewWriter(ps, 64)
+	pkt, _ := rd.ReadPacket() // Invoke
+
+	if sendMessage {
+		_ = wr.WritePacket(drpcwire.Packet{
+			ID:   pkt.ID,
+			Kind: drpcwire.KindMessage,
+			Data: []byte{},
+		})
+		_ = wr.Flush()
+	}
+	_, _ = rd.ReadPacket() // Close
+	close(done)
+}
+
+func runUnaryServerSide(ps net.Conn, t *testing.T, response string, done chan struct{}) {
+	rd := drpcwire.NewReader(ps)
+	wr := drpcwire.NewWriter(ps, 64)
+	_, _ = rd.ReadPacket()    // Invoke
+	_, _ = rd.ReadPacket()    // Message
+	pkt, _ := rd.ReadPacket() // CloseSend
+
+	_ = wr.WritePacket(drpcwire.Packet{
+		Data: []byte(response),
+		ID:   drpcwire.ID{Stream: pkt.ID.Stream, Message: 1},
+		Kind: drpcwire.KindMessage,
+	})
+	_ = wr.Flush()
+	_, _ = rd.ReadPacket() // Close
+	close(done)
+}
+
+func TestInterceptors_TableDriven(t *testing.T) {
+	type testCase struct {
+		name               string
+		unaryInterceptors  []drpcinterceptors.UnaryClientInterceptor
+		streamInterceptors []drpcinterceptors.StreamClientInterceptor
+		expectUnaryCalls   []string
+		expectStreamCalls  []string
+		expectUnaryResult  string
+		expectUnaryError   bool
+		expectStreamError  bool
+		serverFunc         func(ps net.Conn, t *testing.T, done chan struct{})
+	}
+
+	cases := []testCase{
+		{
+			name: "unary interceptor chain executes in correct order",
+			unaryInterceptors: []drpcinterceptors.UnaryClientInterceptor{
+				func(ctx context.Context, method string, in, out drpc.Message, conn drpc.Conn, enc drpc.Encoding, invoker drpcinterceptors.UnaryInvoker) error {
+					calls := ctx.Value("calls").(*[]string)
+					*calls = append(*calls, "interceptor1_before")
+					err := invoker(ctx, method, in, out, enc)
+					*calls = append(*calls, "interceptor1_after")
+					return err
+				},
+				func(ctx context.Context, method string, in, out drpc.Message, conn drpc.Conn, enc drpc.Encoding, invoker drpcinterceptors.UnaryInvoker) error {
+					calls := ctx.Value("calls").(*[]string)
+					*calls = append(*calls, "interceptor2_before")
+					err := invoker(ctx, method, in, out, enc)
+					*calls = append(*calls, "interceptor2_after")
+					return err
+				},
+			},
+			expectUnaryCalls:  []string{"interceptor1_before", "interceptor2_before", "interceptor2_after", "interceptor1_after"},
+			expectUnaryResult: "output",
+			serverFunc: func(ps net.Conn, t *testing.T, done chan struct{}) {
+				runUnaryServerSide(ps, t, "output", done)
+			},
+		},
+		{
+			name: "stream interceptor chain executes in correct order",
+			streamInterceptors: []drpcinterceptors.StreamClientInterceptor{
+				func(ctx context.Context, method string, conn drpc.Conn, streamer drpcinterceptors.Streamer) (drpc.Stream, error) {
+					calls := ctx.Value("calls").(*[]string)
+					*calls = append(*calls, "streamInterceptor1_before")
+					stream, err := streamer(ctx, method)
+					*calls = append(*calls, "streamInterceptor1_after")
+					return stream, err
+				},
+				func(ctx context.Context, method string, conn drpc.Conn, streamer drpcinterceptors.Streamer) (drpc.Stream, error) {
+					calls := ctx.Value("calls").(*[]string)
+					*calls = append(*calls, "streamInterceptor2_before")
+					stream, err := streamer(ctx, method)
+					*calls = append(*calls, "streamInterceptor2_after")
+					return stream, err
+				},
+			},
+			expectStreamCalls: []string{"streamInterceptor1_before", "streamInterceptor2_before", "streamInterceptor2_after", "streamInterceptor1_after"},
+			serverFunc: func(ps net.Conn, t *testing.T, done chan struct{}) {
+				runStreamServerSide(ps, t, true, done)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := drpctest.NewTracker(t)
+			pc, ps := net.Pipe()
+			defer pc.Close()
+			defer ps.Close()
+
+			var unaryCalls, streamCalls []string
+			unaryCalled := false
+			streamCalled := false
+
+			ctxVal := context.WithValue(ctx, "calls", &unaryCalls)
+			ctxVal = context.WithValue(ctxVal, "unaryCalled", &unaryCalled)
+			ctxVal = context.WithValue(ctxVal, "streamCalled", &streamCalled)
+
+			dialOpts := drpcinterceptors.NewDialOptions(nil)
+			if len(tc.unaryInterceptors) > 0 {
+				dialOpts = drpcinterceptors.NewDialOptions([]drpcinterceptors.DialOption{
+					drpcinterceptors.WithChainUnaryInterceptor(tc.unaryInterceptors...),
+				})
+			}
+			if len(tc.streamInterceptors) > 0 {
+				dialOpts = drpcinterceptors.NewDialOptions([]drpcinterceptors.DialOption{
+					drpcinterceptors.WithChainStreamInterceptor(tc.streamInterceptors...),
+				})
+			}
+
+			opts := Options{
+				dopts: *dialOpts,
+			}
+			conn := NewWithOptions(pc, opts)
+			done := make(chan struct{})
+
+			ctx.Run(func(ctx context.Context) {
+				tc.serverFunc(ps, t, done)
+			})
+
+			if len(tc.unaryInterceptors) > 0 {
+				in, out := "input", ""
+				err := conn.Invoke(ctxVal, "TestMethod", testEncoding{}, &in, &out)
+				if tc.expectUnaryError {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+					assert.Equal(t, tc.expectUnaryResult, out)
+					if len(tc.expectUnaryCalls) > 0 {
+						assert.Equal(t, tc.expectUnaryCalls, unaryCalls)
+					}
+				}
+			}
+
+			if len(tc.streamInterceptors) > 0 {
+				ctxVal = context.WithValue(ctx, "calls", &streamCalls)
+				stream, err := conn.NewStream(ctxVal, "TestStreamMethod", testEncoding{})
+				if tc.expectStreamError {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+					stream.Close()
+					if len(tc.expectStreamCalls) > 0 {
+						assert.Equal(t, tc.expectStreamCalls, streamCalls)
+					}
+				}
+			}
+
+			if tc.name == "mixed interceptors work together" {
+				assert.True(t, unaryCalled)
+				assert.True(t, streamCalled)
+			}
+
+			<-done
+		})
 	}
 }

--- a/drpcinterceptors/client_interceptors.go
+++ b/drpcinterceptors/client_interceptors.go
@@ -1,0 +1,125 @@
+package drpcinterceptors
+
+import (
+	"context"
+	"storj.io/drpc"
+)
+
+type UnaryClientInterceptor func(ctx context.Context, rpc string, in, out drpc.Message, cc drpc.Conn, enc drpc.Encoding, next UnaryInvoker) error
+
+type UnaryInvoker func(ctx context.Context, rpc string, in, out drpc.Message, enc drpc.Encoding) error
+
+// Streamer is a function that opens a new DRPC stream.
+type Streamer func(ctx context.Context, method string) (drpc.Stream, error)
+
+// StreamClientInterceptor is the DRPC equivalent of a gRPC stream client interceptor.
+type StreamClientInterceptor func(ctx context.Context, method string, conn drpc.Conn, streamer Streamer) (drpc.Stream, error)
+
+// this is same as ClientConnOptions
+type DialOptions struct {
+	UnaryInt   UnaryClientInterceptor
+	unaryInts  []UnaryClientInterceptor
+	StreamInt  StreamClientInterceptor
+	streamInts []StreamClientInterceptor
+}
+
+type DialOption func(options *DialOptions)
+
+func WithChainUnaryInterceptor(ints ...UnaryClientInterceptor) DialOption {
+	return func(opt *DialOptions) {
+		opt.unaryInts = append(opt.unaryInts, ints...)
+	}
+}
+
+func WithChainStreamInterceptor(ints ...StreamClientInterceptor) DialOption {
+	return func(opt *DialOptions) {
+		opt.streamInts = append(opt.streamInts, ints...)
+	}
+}
+
+func NewDialOptions(opts []DialOption) *DialOptions {
+	options := &DialOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+	return options
+}
+
+// ChainUnaryClientInterceptors chains all unary client interceptors in the DialOptions into a single interceptor.
+//
+// This method inspects the slice of unary client interceptors (`d.unaryInts`) and combines them into one interceptor,
+// assigning the result to `d.UnaryInt`. If there are no interceptors, `d.UnaryInt` is set to nil. If there is only one,
+// it is used directly. If there are multiple, they are chained so that each interceptor can process the request and
+// pass control to the next, ending with the original invoker.
+//
+// The interceptors are invoked in the order they were added.
+//
+// Example usage:
+//
+//	opts := &drpcinterceptors.DialOptions{}
+//	drpcinterceptors.WithChainUnaryInterceptor(loggingInterceptor, authInterceptor)(opts)
+//	opts.ChainUnaryClientInterceptors()
+//	// opts.UnaryInt now contains the chained interceptor.
+//
+// Side effects:
+//   - Sets d.UnaryInt to the chained interceptor or nil.
+func (d *DialOptions) ChainUnaryClientInterceptors() {
+	switch n := len(d.unaryInts); n {
+	case 0:
+		d.UnaryInt = nil
+	case 1:
+		d.UnaryInt = d.unaryInts[0]
+	default:
+		d.UnaryInt = func(ctx context.Context, method string, in, out drpc.Message, conn drpc.Conn, enc drpc.Encoding, invoker UnaryInvoker) error {
+			chained := invoker
+			for i := n - 1; i >= 0; i-- {
+				next := chained
+				interceptor := d.unaryInts[i]
+				chained = func(ctx context.Context, method string, in, out drpc.Message, enc drpc.Encoding) error {
+					return interceptor(ctx, method, in, out, conn, enc, next)
+				}
+			}
+			return chained(ctx, method, in, out, enc)
+		}
+	}
+}
+
+// ChainStreamClientInterceptors chains all stream client interceptors in the DialOptions into a single interceptor.
+//
+// This method examines the slice of stream client interceptors (`d.streamInts`) and combines them into one interceptor,
+// assigning the result to `d.StreamInt`. If there are no interceptors, `d.StreamInt` is set to nil. If there is only one,
+// it is used directly. If there are multiple, they are chained so that each interceptor can process the stream request
+// and pass control to the next, ending with the original streamer.
+//
+// The interceptors are invoked in the order they were added.
+//
+// Example usage:
+//
+//	opts := &drpcinterceptors.DialOptions{}
+//	drpcinterceptors.WithChainStreamInterceptor(loggingInterceptor, metricsInterceptor)(opts)
+//	opts.ChainStreamClientInterceptors()
+//	// opts.StreamInt now contains the chained stream interceptor.
+//
+// Side effects:
+//   - Sets d.StreamInt to the chained interceptor or nil.
+func (d *DialOptions) ChainStreamClientInterceptors() {
+	n := len(d.streamInts)
+	switch n {
+	case 0:
+		d.StreamInt = nil
+	case 1:
+		d.StreamInt = d.streamInts[0]
+	default:
+		d.StreamInt = func(ctx context.Context, method string, conn drpc.Conn, streamer Streamer) (drpc.Stream, error) {
+			chained := streamer
+			for i := n - 1; i >= 0; i-- {
+				next := chained
+				interceptor := d.streamInts[i]
+				chained = func(ctx context.Context, method string) (drpc.Stream, error) {
+					return interceptor(ctx, method, conn, next)
+				}
+			}
+			return chained(ctx, method)
+		}
+	}
+}

--- a/drpcinterceptors/client_interceptors_test.go
+++ b/drpcinterceptors/client_interceptors_test.go
@@ -1,0 +1,19 @@
+package drpcinterceptors
+
+import (
+	"github.com/zeebo/assert"
+	"testing"
+)
+
+func TestNoInterceptorsReturnsNil(t *testing.T) {
+	// Create empty options with no interceptors
+	dialOpts := NewDialOptions([]DialOption{})
+
+	// Chain the interceptors (which should set nil)
+	dialOpts.ChainUnaryClientInterceptors()
+	dialOpts.ChainStreamClientInterceptors()
+
+	// Verify both interceptors are nil
+	assert.Nil(t, dialOpts.UnaryInt)
+	assert.Nil(t, dialOpts.StreamInt)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,14 @@ module storj.io/drpc
 go 1.19
 
 require (
+	github.com/stretchr/testify v1.10.0
 	github.com/zeebo/assert v1.3.0
 	github.com/zeebo/errs v1.2.2
 	google.golang.org/protobuf v1.27.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/errs v1.2.2 h1:5NFypMTuSdoySVTqlNs1dEoU21QVamMQJxW/Fii5O7g=
@@ -10,3 +16,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
**Add support for client-side interceptors in drpc**

This PR introduces support for unary and stream client-side interceptors in drpc by:
	•	Adding UnaryClientInterceptor and StreamClientInterceptor interface definitions.
	•	Introducing a DialOptions struct to hold interceptor configurations.
	•	Updating drpcconn.Conn to accept DialOptions and invoke interceptors in Invoke and NewStream.

Interceptor definitions are modeled after gRPC to simplify migration from existing gRPC interceptors in CRDB.