### PR TITLE
drpcclient: add client interceptor support in drpc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 vendor
 result
+.idea/*

--- a/drpcclient/client_interceptors.go
+++ b/drpcclient/client_interceptors.go
@@ -1,0 +1,37 @@
+package drpcclient
+
+import (
+	"context"
+	"storj.io/drpc"
+)
+
+// UnaryInvoker is called by UnaryClientInterceptor to execute the actual RPC.
+// It is responsible for sending the request message to the server
+// and receiving the response from the server.
+type UnaryInvoker func(ctx context.Context, rpc string, enc drpc.Encoding, in, out drpc.Message, cc *ClientConn) error
+
+// UnaryClientInterceptor defines a function type for intercepting unary RPC calls on the client side.
+// This interceptor allows you to add custom logic before and/or after the execution of a unary RPC.
+// It can be used for cross-cutting concerns such as logging, metrics, authentication, or error handling.
+//
+// Unary interceptors can be added to a ClientConn by passing them as DialOption using the WithChainUnaryInterceptor()
+// during client connection setup.
+//
+// The interceptor must call `next` to proceed with the RPC, unless it intends to short-circuit the call.
+// It should return an error compatible with the drpcerr package if the RPC fails.
+type UnaryClientInterceptor func(ctx context.Context, rpc string, enc drpc.Encoding, in, out drpc.Message, cc *ClientConn, next UnaryInvoker) error
+
+// Streamer is a function that opens a new DRPC stream.
+type Streamer func(ctx context.Context, rpc string, enc drpc.Encoding, cc *ClientConn) (drpc.Stream, error)
+
+// StreamClientInterceptor defines a function type for intercepting streaming RPC calls on the client side.
+// This interceptor allows you to add custom logic before and/or after the creation of a streaming RPC.
+// It can be used for cross-cutting concerns such as logging, metrics, authentication, or error handling.
+//
+// Stream interceptors can be added to a ClientConn by passing them as DialOption using the WithChainStreamInterceptor()
+// during client connection setup.
+//
+// The interceptor must call `streamer` to proceed with the RPC, unless it intends to short-circuit the call.
+// It should return the stream created by the streamer function or an error if the operation fails. The error should be
+// compatible with the drpcerr package.
+type StreamClientInterceptor func(ctx context.Context, rpc string, enc drpc.Encoding, cc *ClientConn, streamer Streamer) (drpc.Stream, error)

--- a/drpcclient/clientconn.go
+++ b/drpcclient/clientconn.go
@@ -1,0 +1,140 @@
+package drpcclient
+
+import (
+	"context"
+	"storj.io/drpc"
+)
+
+// DialerFunc is a function that returns a drpc.Conn or an error.
+type DialerFunc func(ctx context.Context) (drpc.Conn, error)
+
+// ClientConn represents a DRPC client connection, with support for configuring the
+// connection with dial options such as interceptors.
+type ClientConn struct {
+	drpc.Conn
+	dopts dialOptions
+}
+
+// NewClientConnWithOptions creates a new ClientConn with the specified dial options
+// and dialer function. The dialer function is used to obtain the underlying drpc.Conn,
+// either from a pool or a concrete connection.
+func NewClientConnWithOptions(ctx context.Context, dialer DialerFunc, opts ...DialOption) (*ClientConn, error) {
+	conn, err := dialer(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	clientConn := &ClientConn{
+		Conn:  conn,
+		dopts: defaultDialOptions(),
+	}
+	for _, opt := range opts {
+		opt(&clientConn.dopts)
+	}
+	clientConn.initInterceptors()
+	return clientConn, nil
+}
+
+// finalInvoker returns a UnaryInvoker which executes at the end in an interceptor chain.
+func finalInvoker(ctx context.Context, rpc string, enc drpc.Encoding, in, out drpc.Message, cc *ClientConn) error {
+	return cc.Conn.Invoke(ctx, rpc, enc, in, out)
+}
+
+func (c *ClientConn) Invoke(ctx context.Context, rpc string, enc drpc.Encoding, in, out drpc.Message) error {
+	if c.dopts.unaryInt != nil {
+		return c.dopts.unaryInt(ctx, rpc, enc, in, out, c, finalInvoker)
+	}
+	return c.Conn.Invoke(ctx, rpc, enc, in, out)
+}
+
+// finalStreamer returns a Streamer which executes at the end in an interceptor chain.
+func finalStreamer(ctx context.Context, rpc string, enc drpc.Encoding, cc *ClientConn) (drpc.Stream, error) {
+	return cc.Conn.NewStream(ctx, rpc, enc)
+}
+
+func (c *ClientConn) NewStream(ctx context.Context, rpc string, enc drpc.Encoding) (drpc.Stream, error) {
+	if c.dopts.streamInt != nil {
+		return c.dopts.streamInt(ctx, rpc, enc, c, finalStreamer)
+	}
+	return c.Conn.NewStream(ctx, rpc, enc)
+}
+
+func (c *ClientConn) initInterceptors() {
+	chainUnaryClientInterceptors(c)
+	chainStreamClientInterceptors(c)
+}
+
+var _ drpc.Conn = (*ClientConn)(nil)
+
+// chainUnaryClientInterceptors chains all unary client interceptors in the dialOptions into a single interceptor.
+// The combined chained interceptor is stored in dopts.unaryInt. The interceptors are invoked in the order they were added.
+//
+// Example usage:
+//
+//	// Create a ClientConn and add interceptors
+//	clientConn := &ClientConn{
+//	    dopts: dialOptions{
+//	        unaryInts: []UnaryClientInterceptor{loggingInterceptor, metricsInterceptor},
+//	    },
+//	}
+//
+//	// Chain the interceptors
+//	chainUnaryClientInterceptors(clientConn)
+//	// clientConn.dopts.unaryInt now contains the chained unary interceptor.
+func chainUnaryClientInterceptors(cc *ClientConn) {
+	switch n := len(cc.dopts.unaryInts); n {
+	case 0:
+		cc.dopts.unaryInt = nil
+	case 1:
+		cc.dopts.unaryInt = cc.dopts.unaryInts[0]
+	default:
+		cc.dopts.unaryInt = func(ctx context.Context, rpc string, enc drpc.Encoding, in, out drpc.Message, conn *ClientConn, invoker UnaryInvoker) error {
+			chained := invoker
+			for i := n - 1; i >= 0; i-- {
+				next := chained
+				interceptor := cc.dopts.unaryInts[i]
+				chained = func(ctx context.Context, rpc string, enc drpc.Encoding, in, out drpc.Message, clientConn *ClientConn) error {
+					return interceptor(ctx, rpc, enc, in, out, clientConn, next)
+				}
+			}
+			return chained(ctx, rpc, enc, in, out, conn)
+		}
+	}
+}
+
+// chainStreamClientInterceptors chains all stream client interceptors in the dialOptions into a single interceptor.
+// The combined chained stream interceptor is stored in dopts.streamInt. The interceptors are invoked in the order they were added.
+//
+// Example usage:
+//
+//	// Create a ClientConn and add interceptors
+//	clientConn := &ClientConn{
+//	    dopts: dialOptions{
+//	        streamInts: []StreamClientInterceptor{loggingInterceptor, metricsInterceptor},
+//	    },
+//	}
+//
+//	// Chain the interceptors
+//	chainStreamClientInterceptors(clientConn)
+//	// clientConn.dopts.streamInt now contains the chained stream interceptor.
+func chainStreamClientInterceptors(cc *ClientConn) {
+	n := len(cc.dopts.streamInts)
+	switch n {
+	case 0:
+		cc.dopts.streamInt = nil
+	case 1:
+		cc.dopts.streamInt = cc.dopts.streamInts[0]
+	default:
+		cc.dopts.streamInt = func(ctx context.Context, rpc string, enc drpc.Encoding, conn *ClientConn, streamer Streamer) (drpc.Stream, error) {
+			chained := streamer
+			for i := n - 1; i >= 0; i-- {
+				next := chained
+				interceptor := cc.dopts.streamInts[i]
+				chained = func(ctx context.Context, rpc string, enc drpc.Encoding, clientConn *ClientConn) (drpc.Stream, error) {
+					return interceptor(ctx, rpc, enc, clientConn, next)
+				}
+			}
+			return chained(ctx, rpc, enc, conn)
+		}
+	}
+}

--- a/drpcclient/clientconn_test.go
+++ b/drpcclient/clientconn_test.go
@@ -1,0 +1,200 @@
+package drpcclient
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"storj.io/drpc"
+	"storj.io/drpc/drpcpool"
+	"storj.io/drpc/drpctest"
+	"testing"
+	"time"
+)
+
+// Dummy encoding, which assumes the drpc.Message is a *string.
+type testEncoding struct{}
+
+func (testEncoding) Marshal(msg drpc.Message) ([]byte, error) {
+	return []byte(*msg.(*string)), nil
+}
+
+func (testEncoding) Unmarshal(buf []byte, msg drpc.Message) error {
+	*msg.(*string) = string(buf)
+	return nil
+}
+
+// TestUnaryInterceptorChainWithPooledAndConcreteDrpcConn verifies that unary interceptors
+// work correctly with both direct drpcconn.Conn and pooled drpcpool.Conn connection types.
+//
+// This test ensures that:
+// 1. The interceptor chain executes properly in both connection scenarios
+// 2. Interceptors are called in the correct order (first-to-last on the way in, last-to-first on the way out)
+// 3. The RPC payload is correctly transmitted through the interceptor chain
+func TestUnaryInterceptorChainWithPooledAndConcreteDrpcConn(t *testing.T) {
+	ctx := drpctest.NewTracker(t)
+
+	// Test cases for different connection supplier implementations
+	testCases := []struct {
+		name   string
+		dialer func(context.Context) (drpc.Conn, error)
+	}{
+		{
+			name: "drpc_connection",
+			// Basic connection supplier that returns a concrete connection directly
+			dialer: func(context.Context) (drpc.Conn, error) {
+				return &mockDrpcConn{}, nil
+			},
+		},
+		{
+			name: "drpc_pooled_connection",
+			// Pool-based connection supplier that returns connections from a connection pool
+			dialer: func(context.Context) (drpc.Conn, error) {
+				pool := drpcpool.New[string, drpcpool.Conn](drpcpool.Options{
+					Capacity:    2,
+					KeyCapacity: 1,
+					Expiration:  time.Minute,
+				})
+				t.Cleanup(func() {
+					pool.Close()
+				})
+				// Get a connection from the pool using a test server address
+				return pool.Get(ctx, "test.server:8080", func(ctx context.Context, addr string) (drpcpool.Conn, error) {
+					return &mockDrpcConn{}, nil
+				}), nil
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		var interceptorCalls []string
+
+		interceptor1 := recordUnaryInterceptor("interceptor1", &interceptorCalls)
+		interceptor2 := recordUnaryInterceptor("interceptor2", &interceptorCalls)
+		in, out := "foobar", ""
+		cc, _ := NewClientConnWithOptions(ctx, tc.dialer, WithChainUnaryInterceptor(interceptor1, interceptor2))
+		assert.NoError(t, cc.Invoke(ctx, "TestMethod", testEncoding{}, &in, &out))
+		assert.Equal(t, out, "mocked response for request: "+in)
+
+		// Check the order of interceptor calls
+		expected := []string{
+			"interceptor1_before",
+			"interceptor2_before",
+			"interceptor2_after",
+			"interceptor1_after",
+		}
+		assert.Equal(t, expected, interceptorCalls)
+	}
+}
+
+func TestInvokeWithNoInterceptors(t *testing.T) {
+	ctx := drpctest.NewTracker(t)
+
+	// Connection dialer that returns a mock connection directly
+	dialer := func(ctx2 context.Context) (drpc.Conn, error) {
+		return &mockDrpcConn{}, nil
+	}
+
+	in, out := "foobar", ""
+	cc, _ := NewClientConnWithOptions(ctx, dialer, WithChainUnaryInterceptor())
+	assert.NoError(t, cc.Invoke(ctx, "TestMethod", testEncoding{}, &in, &out))
+	assert.True(t, out == "mocked response for request: "+in)
+}
+
+func TestChainStreamClientInterceptors(t *testing.T) {
+	ctx := drpctest.NewTracker(t)
+
+	// Mock connection dialer
+	dialer := func(ctx2 context.Context) (drpc.Conn, error) {
+		return &mockDrpcConn{}, nil
+	}
+
+	var interceptorCalls []string
+
+	// Define interceptors
+
+	interceptor1 := recordStreamInterceptor("interceptor1", &interceptorCalls)
+	interceptor2 := recordStreamInterceptor("interceptor2", &interceptorCalls)
+
+	// Create ClientConn using NewClientConnWithOptions
+	cc, err := NewClientConnWithOptions(ctx, dialer, WithChainStreamInterceptor(interceptor1, interceptor2))
+	assert.NoError(t, err)
+
+	// Invoke the chained interceptor
+	_, err = cc.NewStream(ctx, "TestRPC", testEncoding{})
+	assert.NoError(t, err)
+	// Check the order of interceptor calls
+	expected := []string{
+		"interceptor1_before",
+		"interceptor2_before",
+		"interceptor2_after",
+		"interceptor1_after",
+	}
+	assert.Equal(t, expected, interceptorCalls)
+}
+
+func recordUnaryInterceptor(name string, calls *[]string) UnaryClientInterceptor {
+	return func(ctx context.Context, method string, enc drpc.Encoding,
+		in, out drpc.Message, conn *ClientConn, invoker UnaryInvoker) error {
+		*calls = append(*calls, name+"_before")
+		err := invoker(ctx, method, enc, in, out, conn)
+		*calls = append(*calls, name+"_after")
+		return err
+	}
+}
+
+func recordStreamInterceptor(name string, calls *[]string) StreamClientInterceptor {
+	return func(ctx context.Context, rpc string, enc drpc.Encoding, conn *ClientConn, next Streamer) (drpc.Stream, error) {
+		*calls = append(*calls, name+"_before")
+		stream, err := next(ctx, rpc, enc, conn)
+		if err == nil {
+			*calls = append(*calls, name+"_after")
+		}
+		return stream, err
+	}
+}
+
+type mockDrpcConn struct{}
+
+func (m *mockDrpcConn) Unblocked() <-chan struct{} {
+	return nil
+}
+
+func (m *mockDrpcConn) Invoke(ctx context.Context, rpc string, enc drpc.Encoding, in, out drpc.Message) error {
+	*out.(*string) = "mocked response for request: " + *in.(*string)
+	return nil
+}
+
+func (m *mockDrpcConn) NewStream(ctx context.Context, rpc string, enc drpc.Encoding) (drpc.Stream, error) {
+	return &mockStream{name: rpc}, nil
+}
+
+func (m *mockDrpcConn) Close() error {
+	return nil
+}
+
+func (m *mockDrpcConn) Closed() <-chan struct{} {
+	return nil
+}
+
+type mockStream struct {
+	name string
+}
+
+func (m *mockStream) MsgSend(msg drpc.Message, enc drpc.Encoding) error {
+	return nil
+}
+
+func (m *mockStream) MsgRecv(msg drpc.Message, enc drpc.Encoding) error {
+	return nil
+}
+
+func (m *mockStream) Close() error {
+	return nil
+}
+
+func (m *mockStream) Context() context.Context {
+	return context.TODO()
+}
+
+func (m *mockStream) CloseSend() error {
+	return nil
+}

--- a/drpcclient/dialoptions.go
+++ b/drpcclient/dialoptions.go
@@ -1,0 +1,34 @@
+package drpcclient
+
+// dialOptions configure a NewClientConnWithOptions call. dialOptions are set by the DialOption
+// values passed to NewClientConnWithOptions.
+type dialOptions struct {
+	unaryInt  UnaryClientInterceptor
+	streamInt StreamClientInterceptor
+
+	unaryInts  []UnaryClientInterceptor
+	streamInts []StreamClientInterceptor
+}
+
+// DialOption configures how we set up the client connection.
+type DialOption func(options *dialOptions)
+
+func defaultDialOptions() dialOptions {
+	return dialOptions{}
+}
+
+// WithChainUnaryInterceptor returns a DialOption that adds one or more unary RPC interceptors,
+// chaining. Last interceptor is the innermost which eventually invokes the UnaryInvoker.
+func WithChainUnaryInterceptor(ints ...UnaryClientInterceptor) DialOption {
+	return func(opt *dialOptions) {
+		opt.unaryInts = append(opt.unaryInts, ints...)
+	}
+}
+
+// WithChainStreamInterceptor returns a DialOption that adds one or more stream RPC interceptors,
+// chaining. Last interceptor is the innermost which eventually invokes the Streamer.
+func WithChainStreamInterceptor(ints ...StreamClientInterceptor) DialOption {
+	return func(opt *dialOptions) {
+		opt.streamInts = append(opt.streamInts, ints...)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,14 @@ module storj.io/drpc
 go 1.19
 
 require (
+	github.com/stretchr/testify v1.10.0
 	github.com/zeebo/assert v1.3.0
 	github.com/zeebo/errs v1.2.2
 	google.golang.org/protobuf v1.27.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/errs v1.2.2 h1:5NFypMTuSdoySVTqlNs1dEoU21QVamMQJxW/Fii5O7g=
@@ -10,3 +16,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Add supports for interceptors in drpc. The changes include
definition of client interceptor interface types, logic to chain multiple
unary/stream interceptors.
This change also introduces a new struct `drpcclient.ClientConn` which
satisfies the `drpc.Conn` interface, and also decorates underlying
drpc Connection object with interceptors. The struct `drpcclient.ClientConn`
is defined such that it can be initialized with a supplier which supplies
underlying connection either concretely or from a pool.

Epic: CRDB-50378
Fixes: #146086