### PR TITLE
create `drpc.ClientConn` wrapping a `drpc.Conn`

### DIFF
--- a/drpcclient/clientconn.go
+++ b/drpcclient/clientconn.go
@@ -2,11 +2,9 @@ package drpcclient
 
 import (
 	"context"
+
 	"storj.io/drpc"
 )
-
-// DialerFunc is a function that returns a drpc.Conn or an error.
-type DialerFunc func(ctx context.Context) (drpc.Conn, error)
 
 // ClientConn represents a DRPC client connection, with support for configuring the
 // connection with dial options such as interceptors.
@@ -15,15 +13,9 @@ type ClientConn struct {
 	dopts dialOptions
 }
 
-// NewClientConnWithOptions creates a new ClientConn with the specified dial options
-// and dialer function. The dialer function is used to obtain the underlying drpc.Conn,
-// either from a pool or a concrete connection.
-func NewClientConnWithOptions(ctx context.Context, dialer DialerFunc, opts ...DialOption) (*ClientConn, error) {
-	conn, err := dialer(ctx)
-	if err != nil {
-		return nil, err
-	}
-
+// NewClientConnWithOptions creates a new ClientConn with the specified dial options and drpc connection.
+// The passed in drpc connection can be either a concrete connection or a pooled connection.
+func NewClientConnWithOptions(ctx context.Context, conn drpc.Conn, opts ...DialOption) (*ClientConn, error) {
 	clientConn := &ClientConn{
 		Conn:  conn,
 		dopts: defaultDialOptions(),

--- a/drpcclient/clientconn_test.go
+++ b/drpcclient/clientconn_test.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"github.com/stretchr/testify/assert"
 	"storj.io/drpc"
-	"storj.io/drpc/drpcpool"
 	"storj.io/drpc/drpctest"
 	"testing"
-	"time"
 )
 
 // Dummy encoding, which assumes the drpc.Message is a *string.
@@ -22,100 +20,54 @@ func (testEncoding) Unmarshal(buf []byte, msg drpc.Message) error {
 	return nil
 }
 
-// TestUnaryInterceptorChainWithPooledAndConcreteDrpcConn verifies that unary interceptors
-// work correctly with both direct drpcconn.Conn and pooled drpcpool.Conn connection types.
+// TestUnaryInterceptorChain verifies that unary interceptors
+// work correctly with a provided drpc.Conn object.
 //
 // This test ensures that:
-// 1. The interceptor chain executes properly in both connection scenarios
+// 1. The interceptor chain executes properly
 // 2. Interceptors are called in the correct order (first-to-last on the way in, last-to-first on the way out)
 // 3. The RPC payload is correctly transmitted through the interceptor chain
-func TestUnaryInterceptorChainWithPooledAndConcreteDrpcConn(t *testing.T) {
+func TestUnaryInterceptorChain(t *testing.T) {
 	ctx := drpctest.NewTracker(t)
 
-	// Test cases for different connection supplier implementations
-	testCases := []struct {
-		name   string
-		dialer func(context.Context) (drpc.Conn, error)
-	}{
-		{
-			name: "drpc_connection",
-			// Basic connection supplier that returns a concrete connection directly
-			dialer: func(context.Context) (drpc.Conn, error) {
-				return &mockDrpcConn{}, nil
-			},
-		},
-		{
-			name: "drpc_pooled_connection",
-			// Pool-based connection supplier that returns connections from a connection pool
-			dialer: func(context.Context) (drpc.Conn, error) {
-				pool := drpcpool.New[string, drpcpool.Conn](drpcpool.Options{
-					Capacity:    2,
-					KeyCapacity: 1,
-					Expiration:  time.Minute,
-				})
-				t.Cleanup(func() {
-					pool.Close()
-				})
-				// Get a connection from the pool using a test server address
-				return pool.Get(ctx, "test.server:8080", func(ctx context.Context, addr string) (drpcpool.Conn, error) {
-					return &mockDrpcConn{}, nil
-				}), nil
-			},
-		},
+	var interceptorCalls []string
+
+	interceptor1 := recordUnaryInterceptor("interceptor1", &interceptorCalls)
+	interceptor2 := recordUnaryInterceptor("interceptor2", &interceptorCalls)
+	in, out := "foobar", ""
+	cc, _ := NewClientConnWithOptions(ctx, &mockDrpcConn{}, WithChainUnaryInterceptor(interceptor1, interceptor2))
+	assert.NoError(t, cc.Invoke(ctx, "TestMethod", testEncoding{}, &in, &out))
+	assert.Equal(t, out, "mocked response for request: "+in)
+
+	// Check the order of interceptor calls
+	expected := []string{
+		"interceptor1_before",
+		"interceptor2_before",
+		"interceptor2_after",
+		"interceptor1_after",
 	}
-
-	for _, tc := range testCases {
-		var interceptorCalls []string
-
-		interceptor1 := recordUnaryInterceptor("interceptor1", &interceptorCalls)
-		interceptor2 := recordUnaryInterceptor("interceptor2", &interceptorCalls)
-		in, out := "foobar", ""
-		cc, _ := NewClientConnWithOptions(ctx, tc.dialer, WithChainUnaryInterceptor(interceptor1, interceptor2))
-		assert.NoError(t, cc.Invoke(ctx, "TestMethod", testEncoding{}, &in, &out))
-		assert.Equal(t, out, "mocked response for request: "+in)
-
-		// Check the order of interceptor calls
-		expected := []string{
-			"interceptor1_before",
-			"interceptor2_before",
-			"interceptor2_after",
-			"interceptor1_after",
-		}
-		assert.Equal(t, expected, interceptorCalls)
-	}
+	assert.Equal(t, expected, interceptorCalls)
 }
 
 func TestInvokeWithNoInterceptors(t *testing.T) {
 	ctx := drpctest.NewTracker(t)
 
-	// Connection dialer that returns a mock connection directly
-	dialer := func(ctx2 context.Context) (drpc.Conn, error) {
-		return &mockDrpcConn{}, nil
-	}
-
 	in, out := "foobar", ""
-	cc, _ := NewClientConnWithOptions(ctx, dialer, WithChainUnaryInterceptor())
+	cc, _ := NewClientConnWithOptions(ctx, &mockDrpcConn{}, WithChainUnaryInterceptor())
 	assert.NoError(t, cc.Invoke(ctx, "TestMethod", testEncoding{}, &in, &out))
 	assert.True(t, out == "mocked response for request: "+in)
 }
 
 func TestChainStreamClientInterceptors(t *testing.T) {
 	ctx := drpctest.NewTracker(t)
-
-	// Mock connection dialer
-	dialer := func(ctx2 context.Context) (drpc.Conn, error) {
-		return &mockDrpcConn{}, nil
-	}
-
 	var interceptorCalls []string
 
 	// Define interceptors
-
 	interceptor1 := recordStreamInterceptor("interceptor1", &interceptorCalls)
 	interceptor2 := recordStreamInterceptor("interceptor2", &interceptorCalls)
 
 	// Create ClientConn using NewClientConnWithOptions
-	cc, err := NewClientConnWithOptions(ctx, dialer, WithChainStreamInterceptor(interceptor1, interceptor2))
+	cc, err := NewClientConnWithOptions(ctx, &mockDrpcConn{}, WithChainStreamInterceptor(interceptor1, interceptor2))
 	assert.NoError(t, err)
 
 	// Invoke the chained interceptor
@@ -132,8 +84,10 @@ func TestChainStreamClientInterceptors(t *testing.T) {
 }
 
 func recordUnaryInterceptor(name string, calls *[]string) UnaryClientInterceptor {
-	return func(ctx context.Context, method string, enc drpc.Encoding,
-		in, out drpc.Message, conn *ClientConn, invoker UnaryInvoker) error {
+	return func(
+		ctx context.Context, method string, enc drpc.Encoding,
+		in, out drpc.Message, conn *ClientConn, invoker UnaryInvoker,
+	) error {
 		*calls = append(*calls, name+"_before")
 		err := invoker(ctx, method, enc, in, out, conn)
 		*calls = append(*calls, name+"_after")
@@ -142,7 +96,13 @@ func recordUnaryInterceptor(name string, calls *[]string) UnaryClientInterceptor
 }
 
 func recordStreamInterceptor(name string, calls *[]string) StreamClientInterceptor {
-	return func(ctx context.Context, rpc string, enc drpc.Encoding, conn *ClientConn, next Streamer) (drpc.Stream, error) {
+	return func(
+		ctx context.Context,
+		rpc string,
+		enc drpc.Encoding,
+		conn *ClientConn,
+		next Streamer,
+	) (drpc.Stream, error) {
 		*calls = append(*calls, name+"_before")
 		stream, err := next(ctx, rpc, enc, conn)
 		if err == nil {


### PR DESCRIPTION
Create a client connection from a `drpc.Conn`. `drpc.Conn` can be a concrete connection or a pooled connection to the target node.