### PR TITLE
drpcmux: add support for server interceptors

### DIFF
--- a/drpcmux/interceptor.go
+++ b/drpcmux/interceptor.go
@@ -1,0 +1,81 @@
+package drpcmux
+
+import (
+	"context"
+
+	"storj.io/drpc"
+)
+
+// UnaryHandler defines the handler for the unary RPC.
+type UnaryHandler func(ctx context.Context, in interface{}) (out interface{}, err error)
+
+// UnaryServerInterceptor defines the server side interceptor for unary RPC.
+type UnaryServerInterceptor func(
+	ctx context.Context, req interface{}, rpc string, handler UnaryHandler) (out interface{}, err error)
+
+func chainUnaryInterceptors(interceptors []UnaryServerInterceptor) UnaryServerInterceptor {
+	switch n := len(interceptors); n {
+	case 0:
+		return nil
+	case 1:
+		return interceptors[0]
+	default:
+		return func(ctx context.Context, req interface{}, rpc string, handler UnaryHandler) (
+			out interface{}, err error,
+		) {
+			return interceptors[0](
+				ctx, req, rpc, getChainedUnaryHandler(interceptors, 1, rpc, handler),
+			)
+		}
+	}
+}
+
+func getChainedUnaryHandler(
+	interceptors []UnaryServerInterceptor, currIdx int, rpc string, handler UnaryHandler,
+) UnaryHandler {
+	if currIdx == len(interceptors) {
+		return handler
+	}
+	return func(ctx context.Context, in interface{}) (out interface{}, err error) {
+		return interceptors[currIdx](
+			ctx, in, rpc, getChainedUnaryHandler(interceptors, currIdx+1, rpc, handler),
+		)
+	}
+}
+
+// StreamHandler defines the handler for the stream RPC.
+type StreamHandler func(ctx context.Context, in drpc.Stream) (out interface{}, err error)
+
+// StreamServerInterceptor defines a server side interceptor for unary RPC.
+type StreamServerInterceptor func(
+	ctx context.Context, stream drpc.Stream, rpc string, handler StreamHandler) (out interface{}, err error)
+
+func chainStreamInterceptors(interceptors []StreamServerInterceptor) StreamServerInterceptor {
+	switch n := len(interceptors); n {
+	case 0:
+		return nil
+	case 1:
+		return interceptors[0]
+	default:
+		return func(ctx context.Context, stream drpc.Stream, rpc string, handler StreamHandler) (
+			out interface{}, err error,
+		) {
+			return interceptors[0](
+				ctx, stream, rpc, getChainedStreamHandler(interceptors, 1, rpc, handler),
+			)
+		}
+	}
+}
+
+func getChainedStreamHandler(
+	interceptors []StreamServerInterceptor, currIdx int, rpc string, handler StreamHandler,
+) StreamHandler {
+	if currIdx == len(interceptors) {
+		return handler
+	}
+	return func(ctx context.Context, in drpc.Stream) (out interface{}, err error) {
+		return interceptors[currIdx](
+			ctx, in, rpc, getChainedStreamHandler(interceptors, currIdx+1, rpc, handler),
+		)
+	}
+}


### PR DESCRIPTION
This change introduces support for server-side interceptors in DRPC. For a deeper understanding of interceptors, refer to the gRPC guide: https://grpc.io/docs/guides/interceptors

Although this functionality logically belongs in the `drpcserver` package, implementing it within `drpcmux` offers a more practical approach, avoiding a substantial refactor.

Fixes: https://github.com/cockroachdb/cockroach/issues/147622