### PR TITLE
drpcmux: remove redundant context parameter from stream handlers

### DIFF
--- a/drpcmux/handle_rpc.go
+++ b/drpcmux/handle_rpc.go
@@ -37,9 +37,9 @@ func (m *Mux) HandleRPC(stream drpc.Stream, rpc string) (err error) {
 				return data.receiver(data.srv, ctx, req, stream)
 			})
 	} else if !data.unitary && m.streamInterceptor != nil {
-		out, err = m.streamInterceptor(stream.Context(), stream, rpc,
-			func(ctx context.Context, st drpc.Stream) (interface{}, error) {
-				return data.receiver(data.srv, ctx, st, stream)
+		out, err = m.streamInterceptor(stream, rpc,
+			func(st drpc.Stream) (interface{}, error) {
+				return data.receiver(data.srv, st.Context(), st, stream)
 			})
 	} else {
 		out, err = data.receiver(data.srv, stream.Context(), in, stream)

--- a/drpcmux/interceptor.go
+++ b/drpcmux/interceptor.go
@@ -7,7 +7,7 @@ import (
 )
 
 // UnaryHandler defines the handler for the unary RPC.
-type UnaryHandler func(ctx context.Context, in interface{}) (out interface{}, err error)
+type UnaryHandler func(ctx context.Context, req interface{}) (out interface{}, err error)
 
 // UnaryServerInterceptor defines the server side interceptor for unary RPC.
 type UnaryServerInterceptor func(
@@ -36,19 +36,19 @@ func getChainedUnaryHandler(
 	if currIdx == len(interceptors) {
 		return handler
 	}
-	return func(ctx context.Context, in interface{}) (out interface{}, err error) {
+	return func(ctx context.Context, req interface{}) (out interface{}, err error) {
 		return interceptors[currIdx](
-			ctx, in, rpc, getChainedUnaryHandler(interceptors, currIdx+1, rpc, handler),
+			ctx, req, rpc, getChainedUnaryHandler(interceptors, currIdx+1, rpc, handler),
 		)
 	}
 }
 
 // StreamHandler defines the handler for the stream RPC.
-type StreamHandler func(ctx context.Context, in drpc.Stream) (out interface{}, err error)
+type StreamHandler func(stream drpc.Stream) (out interface{}, err error)
 
 // StreamServerInterceptor defines a server side interceptor for unary RPC.
 type StreamServerInterceptor func(
-	ctx context.Context, stream drpc.Stream, rpc string, handler StreamHandler) (out interface{}, err error)
+	stream drpc.Stream, rpc string, handler StreamHandler) (out interface{}, err error)
 
 func chainStreamInterceptors(interceptors []StreamServerInterceptor) StreamServerInterceptor {
 	switch n := len(interceptors); n {
@@ -57,11 +57,11 @@ func chainStreamInterceptors(interceptors []StreamServerInterceptor) StreamServe
 	case 1:
 		return interceptors[0]
 	default:
-		return func(ctx context.Context, stream drpc.Stream, rpc string, handler StreamHandler) (
+		return func(stream drpc.Stream, rpc string, handler StreamHandler) (
 			out interface{}, err error,
 		) {
 			return interceptors[0](
-				ctx, stream, rpc, getChainedStreamHandler(interceptors, 1, rpc, handler),
+				stream, rpc, getChainedStreamHandler(interceptors, 1, rpc, handler),
 			)
 		}
 	}
@@ -73,9 +73,9 @@ func getChainedStreamHandler(
 	if currIdx == len(interceptors) {
 		return handler
 	}
-	return func(ctx context.Context, in drpc.Stream) (out interface{}, err error) {
+	return func(stream drpc.Stream) (out interface{}, err error) {
 		return interceptors[currIdx](
-			ctx, in, rpc, getChainedStreamHandler(interceptors, currIdx+1, rpc, handler),
+			stream, rpc, getChainedStreamHandler(interceptors, currIdx+1, rpc, handler),
 		)
 	}
 }


### PR DESCRIPTION
This change simplifies the API by removing the explicit context parameter from StreamHandler and StreamServerInterceptor interfaces since it can be retrieved from the stream itself via stream.Context().