### PR TITLE
drpcmux: fix server interceptor selection logic

### DIFF
--- a/drpcmux/handle_rpc.go
+++ b/drpcmux/handle_rpc.go
@@ -12,45 +12,74 @@ import (
 )
 
 // HandleRPC handles the rpc that has been requested by the stream.
-func (m *Mux) HandleRPC(stream drpc.Stream, rpc string) (err error) {
+func (m *Mux) HandleRPC(originalStream drpc.Stream, rpc string) (err error) {
 	data, ok := m.rpcs[rpc]
 	if !ok {
 		return drpc.ProtocolError.New("unknown rpc: %q", rpc)
 	}
 
-	in := interface{}(stream)
-	if data.in1 != streamType {
-		msg, ok := reflect.New(data.in1.Elem()).Interface().(drpc.Message)
-		if !ok {
-			return drpc.InternalError.New("invalid rpc input type")
-		}
-		if err := stream.MsgRecv(msg, data.enc); err != nil {
-			return errs.Wrap(err)
-		}
-		in = msg
-	}
-
+	in := interface{}(originalStream)
 	var out drpc.Message
-	if data.unitary && m.unaryInterceptor != nil {
-		out, err = m.unaryInterceptor(stream.Context(), in, rpc,
+
+	// Select interceptor based on RPC type. Note: data.unitary means if the RPC
+	// has unary input and output.
+	switch {
+	case data.unitary && m.unaryInterceptor != nil:
+		// Unary interceptor for unary RPCs (unary -> unary)
+		in, err = m.msgRecv(data, originalStream)
+		if err != nil {
+			break
+		}
+		out, err = m.unaryInterceptor(originalStream.Context(), in, rpc,
 			func(ctx context.Context, req interface{}) (interface{}, error) {
-				return data.receiver(data.srv, ctx, req, stream)
+				return data.receiver(data.srv, ctx, req, originalStream)
 			})
-	} else if !data.unitary && m.streamInterceptor != nil {
-		out, err = m.streamInterceptor(stream, rpc,
-			func(st drpc.Stream) (interface{}, error) {
-				return data.receiver(data.srv, st.Context(), st, stream)
-			})
-	} else {
-		out, err = data.receiver(data.srv, stream.Context(), in, stream)
+	case !data.unitary && m.streamInterceptor != nil:
+		if data.in1 == streamType {
+			// Stream input case (stream -> stream or stream -> unary)
+			out, err = m.streamInterceptor(originalStream, rpc,
+				func(stream drpc.Stream) (interface{}, error) {
+					return data.receiver(data.srv, stream.Context(), stream, stream)
+				})
+		} else {
+			// Unary input with stream output (unary -> stream)
+			out, err = m.streamInterceptor(originalStream, rpc,
+				func(stream drpc.Stream) (interface{}, error) {
+					// Get input message from the stream
+					input, err := m.msgRecv(data, stream)
+					if err != nil {
+						return nil, err
+					}
+					return data.receiver(data.srv, stream.Context(), input, stream)
+				})
+		}
+	default:
+		// Default case with no interceptors.
+		if data.in1 != streamType {
+			// For unary input RPCs with either unary or stream output
+			if in, err = m.msgRecv(data, originalStream); err != nil {
+				break
+			}
+		}
+		out, err = data.receiver(data.srv, originalStream.Context(), in, originalStream)
 	}
 
 	switch {
 	case err != nil:
 		return errs.Wrap(err)
 	case out != nil && !reflect.ValueOf(out).IsNil():
-		return stream.MsgSend(out, data.enc)
+		return originalStream.MsgSend(out, data.enc)
 	default:
-		return stream.CloseSend()
+		return originalStream.CloseSend()
 	}
+}
+
+// msgRecv receives a message from the stream
+func (m *Mux) msgRecv(data rpcData, stream drpc.Stream) (drpc.Message, error) {
+	msg, ok := reflect.New(data.in1.Elem()).Interface().(drpc.Message)
+	if !ok {
+		return msg, drpc.InternalError.New("invalid rpc input type")
+	}
+	err := stream.MsgRecv(msg, data.enc)
+	return msg, errs.Wrap(err)
 }


### PR DESCRIPTION
This commit fixes a bug in the interceptor selection logic in HandleRPC.
The issue was that we were passing a stream to the receiver for the case
where the input is unitary and the output is a stream.

The fix is to receive the message from the stream within the final receiver
after going through the stream interceptor pipeline. This also means we no
longer receive the message outside the switch statement.