### PR TITLE
makefile: add gen-bazel target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 *.test
 .vscode
+.idea/*
 vendor
 result
-.idea/*
+
+# Bazel files, generated with 'make gen-bazel'.
+/WORKSPACE
+BUILD.bazel

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .DEFAULT_GOAL = all
+GO := go
 
 .PHONY: all
 all: tidy docs generate lint vet test
@@ -45,3 +46,17 @@ test:
 	./scripts/run.sh '*'           go test ./...              -race -count=1 -bench=. -benchtime=1x
 	./scripts/run.sh 'integration' go test ./... -tags=gogo   -race -count=1 -bench=. -benchtime=1x
 	./scripts/run.sh 'integration' go test ./... -tags=custom -race -count=1 -bench=. -benchtime=1x
+
+.PHONY: gen-bazel
+gen-bazel:
+	@echo "Generating WORKSPACE"
+	@echo 'workspace(name = "io_storj_drpc")' > WORKSPACE
+	@echo 'Running gazelle...'
+	${GO} run github.com/bazelbuild/bazel-gazelle/cmd/gazelle@v0.40.0 \
+		update --go_prefix=storj.io/drpc --exclude=examples --exclude=scripts --repo_root=.
+	@echo 'You should now be able to build Cockroach using:'
+	@echo '  ./dev build short -- --override_repository=io_storj_drpc=${CURDIR}'
+
+.PHONY: clean-bazel
+clean-bazel:
+	git clean -dxf WORKSPACE BUILD.bazel '**/BUILD.bazel'


### PR DESCRIPTION
This change adds a `gen-bazel` target which generates a `WORKSPACE` file and runs gazelle to generate `BUILD.bazel` files. Generating these files allows a local clone of the repository to be used directly when building cockroach using the `override_repository` flag, for example:

```
./dev build short -- --override_repository=io_storj_drpc=${CURDIR}
```

The new files are added to `.gitignore` so that generating them doesn't interfere with commits.

This also adds a `clean-bazel` target that cleans up these files.

Inspired by: https://github.com/cockroachdb/pebble/commit/cab9f08de0db22259b8c58ebc0980aec7b7eaae0